### PR TITLE
fix: modify angle to fix it being mirrored

### DIFF
--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -6,8 +6,6 @@
 #include <marnav/nmea/mwv.hpp>
 #include <marnav/nmea/xdr.hpp>
 
-#include <base-logging/Logging.hpp>
-
 using namespace marnav;
 using namespace std;
 using namespace wind_lcj_cv7;

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -6,6 +6,8 @@
 #include <marnav/nmea/mwv.hpp>
 #include <marnav/nmea/xdr.hpp>
 
+#include <base-logging/Logging.hpp>
+
 using namespace marnav;
 using namespace std;
 using namespace wind_lcj_cv7;
@@ -77,7 +79,7 @@ void Task::processMWV(marnav::nmea::mwv const& mwv) {
         return;
     }
 
-    double angle = *mwv.get_angle() * M_PI / 180;
+    double angle = (-*mwv.get_angle() + 180) * M_PI / 180;
     double speed = *mwv.get_speed();
 
     auto unit = *mwv.get_speed_unit();

--- a/test/task_test.rb
+++ b/test/task_test.rb
@@ -44,7 +44,7 @@ describe OroGen.wind_lcj_cv7.Task do
         toc = Time.now
 
         expected_speed_v = Eigen::Quaternion.from_angle_axis(
-            214.8 * Math::PI / 180, Eigen::Vector3.UnitZ
+            -34.8 * Math::PI / 180, Eigen::Vector3.UnitZ
         ) * Eigen::Vector3.new(0.1 / 3.6, 0, 0)
         expected_direction_v = expected_speed_v.normalize
         direction_v = speed.velocity.normalize


### PR DESCRIPTION
# What is this PR for
Fix angle being mirrored.

![wind_sensor](https://github.com/tidewise/drivers-orogen-wind_lcj_cv7/assets/7891311/5a5c4011-b5fa-4d0f-8a00-c9cebc5f08de)

# How I did it
To fix it, the angle was inverted and rotated 180° CCW.

![solution](https://github.com/tidewise/drivers-orogen-wind_lcj_cv7/assets/7891311/4cb749a4-8253-4193-87b8-956adc1435b2)

# Results, How I tested
Test already existed. The final angle was changed.

# Checklist
- [x] Assign yourself  in the PR
- [ ] Write unit tests (when relevant)
- [x] Run rubocop and rake tests locally
- [ ] If this PR initialize a CMAKE package please [enable styling and linting](https://github.com/tidewise/wetpaint-buildconf/blob/master/README.md#enabling-styling-and-linting-checks-for-a-cmake-package)
- [ ] Analyse if this PR modifies the UI, if so:
    - [ ] Tested Tupan's simulation (Charts) :world_map:
    - [ ] Tested Tupan's simulation (Hud) :joystick:
    - [ ] Tested ROV's simulation :joystick:
